### PR TITLE
fix typo: imagePullSecrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This chart aims to backup target mysql instances into object storage.
 
 It can read data from a mysql instance or through GCP cloud SQL proxy.
 
-This charts curretnly supports only AWS S3 as object storage.
+This charts currently supports AWS S3 and Google Cloud Storage as object storage.
 
 | Parameter                                           | Description                                                   | Default                            |
 | --------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------- |
@@ -34,7 +34,7 @@ This charts curretnly supports only AWS S3 as object storage.
 | `backup.schedule`                                   | When to run the backup, cron format                           | `0 1 * * *`                        |
 | `backup.image.repository`                           | Image used to perform the backup                              | `softonic/mysql-backup-s3`         |
 | `backup.image.tag`                                  | Tag used for the image                                        | `0.1.5`                            |
-| `backup.image.imagePullSecret`                      | Image pull secret                                             | `null`                             |
+| `backup.image.imagePullSecrets`                     | Image pull secrets                                            | `null`                             |
 | `backup.resources.limits.memory`                    | Resources limits for memory for mysql-backups container       | `1024Mi`                           |
 | `backup.resources.limits.cpu`                       | Resources limits for CPU for mysql-backups container          | `1`                                |
 | `backup.resources.requests.memory`                  | Resources requests for memory for mysql-backups container     | `512Mi`                            |

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,6 +1,7 @@
 Taking snapshots at {{ .Values.backup.schedule }} for
-{{- if .Values.cloudsqlProxy.cloudSQL }}
-{{ .Values.cloudsqlProxy.cloudSQL.instanceId }} ( {{ .Values.cloudsqlProxy.cloudSQL.region }} )
+{{ if .Values.cloudsqlProxy.cloudSQL.enabled -}}
+CloudSQL Proxy: {{ .Values.cloudsqlProxy.cloudSQL.instanceId }} ( {{ .Values.cloudsqlProxy.cloudSQL.region }} )
 {{- else }}
-{{ .Values.mysql.host }}:{{ .Values.mysql.port }}
-{{ end }}
+MySQL-Host: {{ .Values.mysql.host }}:{{ .Values.mysql.port }}
+{{- end }}
+Database(s): {{ .Values.mysql.database }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -79,7 +79,7 @@ spec:
 {{- end }}
             resources:
 {{- toYaml .Values.backup.resources | nindent 14 }}
-{{- if .Values.backup.image.imagePullSecret }}
+{{- if .Values.backup.image.imagePullSecrets }}
           imagePullSecrets:
           - name: {{ .Values.backup.image.imagePullSecrets }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -12,12 +12,12 @@ s3:
   enabled: false
   bucket: null
   filePrefix: mysqldump
+  endpointUrl: null
   secret:
     name: aws-credentials
     keys:
       accessKeyId: accessKeyId
       secretAccessKey: secretAccessKey
-   endpointUrl: null
 
 gcs:
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -29,7 +29,7 @@ backup:
   image:
     repository: softonic/mysql-backup
     tag: 0.3.0
-    imagePullSecret: null
+    imagePullSecrets: null
   resources:
     limits:
       memory: "1024Mi"


### PR DESCRIPTION
if an imagePullSecret is specified, helm fails to compile the chart:

```
Error: template: mysql-backup/templates/cronjob.yaml:80:28: executing "mysql-backup/templates/cronjob.yaml" at <.Values.image.imagePullSecrets>: nil pointer evaluating interface {}.imagePullSecrets
```

this PR fixes this issue.