### PR TITLE
s3 Enabled doesn't disable AWS_SECRET_ACCESS_KEY

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -50,12 +50,12 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.s3.secret.name }}
                   key: {{ .Values.s3.secret.keys.accessKeyId }}
-{{- end }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.s3.secret.name }}
                   key: {{ .Values.s3.secret.keys.secretAccessKey }}
+{{- end }}
 {{- if .Values.s3.endpointUrl }}
             - name: AWS_ENDPOINT_URL
               value: "{{ .Values.s3.endpointUrl }}"


### PR DESCRIPTION
It looks like the conditional for s3 enabled should encapsulate both the access key id and secret access key.