### PR TITLE
feat: allow user to specify more than one database, or to take backup of all databases

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.3.0"
 description: Take mysql backups from any mysql instance to AWS S3. Supports GCP CloudSQL
 name: mysql-backup
 icon: https://avatars0.githubusercontent.com/u/170456
-version: 2.2.0
+version: 2.2.1
 sources:
   - https://github.com/softonic/mysql-backup-chart
 keywords:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This charts curretnly supports only AWS S3 as object storage.
 | --------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------- |
 | `mysql.port`                                        | MySQL instance port                                           | `3306`                             |
 | `mysql.host`                                        | MySQL instance host                                           | `127.0.0.1`                        |
-| `mysql.database`                                    | MySQL instance database name                                  | `null`                             |
+| `mysql.database`                                    | Mysql databases name(s). Space-separated if more than one db, e.g. "db-1 db-2 db3". If null - will try to dump all databases by using `mysqldump --all-databases` flag                              | `null` |
 | `mysql.secret.name`                                 | MySQL credentials Secret name                                 | `mysql-credentials`                |
 | `mysql.secret.keys.user`                            | MySQL user keys in credentials secret                         | `user`                             |
 | `mysql.secret.keys.password`                        | MySQL password keys in credentials secret                     | `password`                         |

--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,7 @@ backup:
   schedule: "0 1 * * *"
   image:
     repository: softonic/mysql-backup
-    tag: 0.3.0
+    tag: 0.4.0
     imagePullSecret: null
   resources:
     limits:


### PR DESCRIPTION
This PR doesn't really introduce any changes. Just some documentation updates related to https://github.com/softonic/mysql-backup/pull/6 plus a bump of container image version