### PR TITLE
Avoid deprecated API versions for batch/v1 cronjobs

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.3.0"
 description: Take mysql backups from any mysql instance to AWS S3. Supports GCP CloudSQL
 name: mysql-backup
 icon: https://avatars0.githubusercontent.com/u/170456
-version: 2.2.1
+version: 2.2.2
 sources:
   - https://github.com/softonic/mysql-backup-chart
 keywords:

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -81,7 +81,7 @@ spec:
 {{- toYaml .Values.backup.resources | nindent 14 }}
 {{- if .Values.backup.image.imagePullSecret }}
           imagePullSecrets:
-          - name: {{ .Values.backup.image.imagePullSecrets }}
+          - name: {{ .Values.backup.image.imagePullSecret }}
 {{- end }}
           {{- with .Values.backup.nodeSelector }}
           nodeSelector:

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "batch/v1" -}}
+apiVersion: batch/v1
+{{- else -}}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-mysqlbackup


### PR DESCRIPTION
1. Avoid deprecated API versions for batch/v1 cronjobs
2. Fix imagePullSecret typo in cronjob