### PR TITLE
feat: Allow TTL to clean up finished jobs

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.3.0"
 description: Take mysql backups from any mysql instance to AWS S3. Supports GCP CloudSQL
 name: mysql-backup
 icon: https://avatars0.githubusercontent.com/u/170456
-version: 2.2.2
+version: 2.2.3
 sources:
   - https://github.com/softonic/mysql-backup-chart
 keywords:

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -10,6 +10,9 @@ spec:
   schedule: "{{ .Values.backup.schedule }}"
   jobTemplate:
     spec:
+{{- if .Values.backup.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.backup.ttlSecondsAfterFinished }}
+{{- end }}
       template:
         metadata:
           labels:

--- a/values.yaml
+++ b/values.yaml
@@ -26,6 +26,7 @@ gcs:
 
 backup:
   schedule: "0 1 * * *"
+  # ttlSecondsAfterFinished: 3600 # Optional (Number of seconds before deleting completed jobs)
   image:
     repository: softonic/mysql-backup
     tag: 0.4.0


### PR DESCRIPTION
According to Kubernetes [job documentation](https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs), it is a good practice to set `ttlSecondsAfterFinished` so jobs are not kept indefinitely, avoiding potential cluster performance degradation.